### PR TITLE
chore: automate npm releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Package version to publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'NanmiCoder/dsh-auto-mode'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Set up package managers
+        run: npm install --global npm@11.19.0 pnpm@10.33.0
+
+      - name: Verify release version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          package_version="$(node --print "require('./package.json').version")"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            test "${GITHUB_REF_NAME}" = "v${package_version}"
+          else
+            test "${RELEASE_VERSION}" = "${package_version}"
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify package
+        run: pnpm verify
+
+      - name: Verify tarball
+        run: npm pack --dry-run --ignore-scripts
+
+      - name: Publish to npm
+        run: npm publish --ignore-scripts --access public


### PR DESCRIPTION
## Summary
- publish npm releases only when a semantic version tag is pushed
- use npm Trusted Publishing with GitHub OIDC instead of a long-lived token
- verify the requested version, full package test suite, and tarball before publishing
- provide a guarded manual dispatch path for release recovery

## Test Plan
- [x] `pnpm verify`
- [x] `npm pack --dry-run --ignore-scripts --access public`
- [x] clean `/tmp` checkout: frozen install, full verification, and package dry-run
- [x] workflow YAML parse